### PR TITLE
Align with Knex version 0.95.0+

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "files": [
         "build-converter.js",
         "build-key-converter.js",
-        "index.js"
+        "index.js",
+        "types.d.ts"
     ],
     "repository": {
         "type": "git",

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,4 +1,4 @@
-import Knex from 'knex';
+import { Knex } from 'knex';
 
 interface AdditionalOptions {
   postProcessResponse(content: string, queryContext: any): string;


### PR DESCRIPTION
The PR addresses major changes in Knex version `0.95+`. See [this](https://github.com/knex/knex/blob/master/UPGRADING.md#upgrading-to-version-0950) for more details.